### PR TITLE
Proposed change to support behavior observed on EventStore 3.5.0:

### DIFF
--- a/src/main/java/com/github/msemys/esjc/subscription/StreamCatchUpSubscription.java
+++ b/src/main/java/com/github/msemys/esjc/subscription/StreamCatchUpSubscription.java
@@ -12,6 +12,7 @@ import static com.github.msemys.esjc.util.Threads.sleepUninterruptibly;
 public class StreamCatchUpSubscription extends CatchUpSubscription {
     private int nextReadEventNumber;
     private int lastProcessedEventNumber;
+    private final int offset;
 
     public StreamCatchUpSubscription(EventStore eventstore,
                                      String streamId,
@@ -25,6 +26,7 @@ public class StreamCatchUpSubscription extends CatchUpSubscription {
         super(eventstore, streamId, resolveLinkTos, listener, userCredentials, readBatchSize, maxPushQueueSize, executor);
         checkArgument(!isNullOrEmpty(streamId), "streamId");
         lastProcessedEventNumber = (fromEventNumberExclusive == null) ? StreamPosition.END : fromEventNumberExclusive;
+        offset = lastProcessedEventNumber + 1;
         nextReadEventNumber = (fromEventNumberExclusive == null) ? StreamPosition.START : fromEventNumberExclusive;
     }
 
@@ -69,7 +71,7 @@ public class StreamCatchUpSubscription extends CatchUpSubscription {
     protected void tryProcess(ResolvedEvent event) {
         boolean processed = false;
 
-        if (event.originalEventNumber() > lastProcessedEventNumber) {
+        if (event.originalEventNumber() + offset > lastProcessedEventNumber) {
             listener.onEvent(this, event);
             lastProcessedEventNumber = event.originalEventNumber();
             processed = true;


### PR DESCRIPTION
When starting a `CatchUpSubscription` at a given event N, the original eventnumber seems to always start at zero - when restarting after "nack"-ing an event.

Not sure if this is a behavior that is changed in later revisions of EventStore.

Patch was created by @nms-ums internally (at our shared client), so I'll include him in this discussion :smile: 