### PR TITLE
Added new constructor to allow construction without protobuf EventRecord

### DIFF
--- a/src/main/java/com/github/msemys/esjc/RecordedEvent.java
+++ b/src/main/java/com/github/msemys/esjc/RecordedEvent.java
@@ -55,6 +55,44 @@ public class RecordedEvent {
      */
     public final Optional<Instant> created;
 
+    
+    /**
+     * Creates new instance with provided data.
+     * 
+     * @param eventStreamId The event stream that this event belongs to.
+     * @param eventId The unique identifier representing this event.
+     * @param eventNumber The number of this event in the stream.
+     * @param eventType The type of event.
+     * @param data A byte array representing the data of this event.
+     * @param metadata A byte array representing the metadata associated with this event.
+     * @param isJson Indicates whether the content is internally marked as JSON.
+     * @param created A datetime representing when this event was created in the system.
+     */    
+    public RecordedEvent(String eventStreamId, UUID eventId, int eventNumber, String eventType, byte[] data,
+            byte[] metadata, boolean isJson, Optional<Instant> created) {
+        super();
+        if (eventStreamId == null) {
+            throw new IllegalArgumentException("eventStreamId == null");
+        }
+        if (eventId == null) {
+            throw new IllegalArgumentException("eventId == null");
+        }
+        if (eventType == null) {
+            throw new IllegalArgumentException("eventType == null");
+        }
+        this.eventStreamId = eventStreamId;
+        this.eventId = eventId;
+        this.eventNumber = eventNumber;
+        this.eventType = eventType;
+        this.data = (data == null ? EMPTY_BYTES : data);
+        this.metadata = (metadata == null ? EMPTY_BYTES : metadata);
+        this.isJson = isJson;
+        this.created = (created == null ? Optional.empty() : created);
+    }
+
+
+
+
     /**
      * Creates new instance from proto message.
      *


### PR DESCRIPTION
I currently try to create a test for a [converter](https://github.com/fuinorg/event-store-commons/blob/master/esjc/src/main/java/org/fuin/esc/esjc/RecordedEvent2CommonEventConverter.java) that transfers a 'RecordedEvent' into another event representation. The 'RecordedEvent' has unfortunately only a 'RecordedEvent(EventRecord)' constructor.  This makes it hard to create some simple test data without creating an 'EventRecord' (I actually do not need for the test).

It would be nice to have an alternative constructor with all data as arguments.