### PR TITLE
! [Operation Timeout] Fixed timeouts not triggering when there is no server response

### DIFF
--- a/src/main/java/com/github/msemys/esjc/operation/manager/OperationItem.java
+++ b/src/main/java/com/github/msemys/esjc/operation/manager/OperationItem.java
@@ -23,7 +23,7 @@ public class OperationItem implements Comparable<OperationItem> {
     public ChannelId connectionId;
     public UUID correlationId;
     public int retryCount;
-    public Instant lastUpdated;
+    public long lastUpdated;
 
     public OperationItem(Operation operation, int maxRetries, Duration timeout) {
         checkNotNull(operation, "operation is null");
@@ -35,7 +35,7 @@ public class OperationItem implements Comparable<OperationItem> {
 
         correlationId = UUID.randomUUID();
         retryCount = 0;
-        lastUpdated = Instant.now();
+        lastUpdated = System.nanoTime();
     }
 
     @Override

--- a/src/main/java/com/github/msemys/esjc/operation/manager/OperationManager.java
+++ b/src/main/java/com/github/msemys/esjc/operation/manager/OperationManager.java
@@ -64,7 +64,7 @@ public class OperationManager {
             if (!item.connectionId.equals(connectionId)) {
                 retryOperations.add(item);
             } else if (!item.timeout.isZero() &&
-                Duration.between(Instant.now(), item.lastUpdated).compareTo(settings.operationTimeout) > 0) {
+                Duration.ofNanos(System.nanoTime() - item.lastUpdated).compareTo(settings.operationTimeout) > 0) {
                 String error = String.format("Operation never got response from server. UTC now: %s, operation: %s.",
                     Instant.now(), item.toString());
 
@@ -145,7 +145,7 @@ public class OperationManager {
             waitingOperations.offer(item);
         } else {
             item.connectionId = ChannelId.of(connection);
-            item.lastUpdated = Instant.now();
+            item.lastUpdated = System.nanoTime();
             activeOperations.put(item.correlationId, item);
 
             TcpPackage tcpPackage = item.operation.create(item.correlationId);


### PR DESCRIPTION
Duration.between(start, end) measures the duration between the start and the end.
If start is after end, the duration becomes negative, which is never larger than any
configured operation timeout.

Using Instant for timeouts is generally a bad idea because the system clock can
change arbitrarily causing timeouts to be fired prematurly or not at all.
System.nanoTime is guaranteed to be monotonically increasing, making it ideal
for timeout calculations.