### PR TITLE
Fix multiple reconnects at the same time

### DIFF
--- a/src/main/java/com/github/msemys/esjc/EventStoreTcp.java
+++ b/src/main/java/com/github/msemys/esjc/EventStoreTcp.java
@@ -809,7 +809,9 @@ public class EventStoreTcp implements EventStore {
 
         switch (connectionState()) {
             case INIT:
-                connectingPhase = ConnectingPhase.RECONNECTING;
+                if (connectingPhase != ConnectingPhase.ENDPOINT_DISCOVERY) {
+                    connectingPhase = ConnectingPhase.RECONNECTING;
+                }
                 discoverEndpoint(task.result);
                 break;
             case CONNECTING:


### PR DESCRIPTION
This fix should prevent multiple reconnects happening at the same time.
We encountered that if you manually connect and open a query around the same time (in a cluster config) that multiple re-connections where scheduled at the same time (finding best eventstore ... 1/10).

There is a check in the "discoverEndpoint" method that checks if the phase is RECONNECTING which did not make any sense before since we always set it to RECONNECTING right before the check here.

Regards David.