### PR TITLE
Use blocking queues to handle congestion more gracefully

### DIFF
--- a/src/main/java/com/github/msemys/esjc/CatchUpSubscription.java
+++ b/src/main/java/com/github/msemys/esjc/CatchUpSubscription.java
@@ -182,7 +182,7 @@ public abstract class CatchUpSubscription implements AutoCloseable {
                                     }
                                 } catch (InterruptedException ex) {
                                     enqueueSubscriptionDropNotification(SubscriptionDropReason.ProcessingQueueOverflow, ex);
-                                    throw new RuntimeException(ex);
+                                    subscription.unsubscribe();
                                 }
                             }
                         }

--- a/src/main/java/com/github/msemys/esjc/EventStoreTcp.java
+++ b/src/main/java/com/github/msemys/esjc/EventStoreTcp.java
@@ -412,7 +412,7 @@ public class EventStoreTcp implements EventStore {
         checkNotNull(settings, "settings is null");
 
         CatchUpSubscription subscription = new StreamCatchUpSubscription(this,
-            stream, eventNumber, settings.resolveLinkTos, listener, userCredentials, settings.readBatchSize, settings.maxLiveQueueSize, executor());
+            stream, eventNumber, settings.resolveLinkTos, listener, userCredentials, settings.readBatchSize, settings.maxLiveQueueSize, settings.maxCongestionWaitTime, executor());
 
         subscription.start();
 
@@ -428,7 +428,7 @@ public class EventStoreTcp implements EventStore {
         checkNotNull(settings, "settings is null");
 
         CatchUpSubscription subscription = new AllCatchUpSubscription(this,
-            position, settings.resolveLinkTos, listener, userCredentials, settings.readBatchSize, settings.maxLiveQueueSize, executor());
+            position, settings.resolveLinkTos, listener, userCredentials, settings.readBatchSize, settings.maxLiveQueueSize, settings.maxCongestionWaitTime, executor());
 
         subscription.start();
 
@@ -929,7 +929,7 @@ public class EventStoreTcp implements EventStore {
                 VolatileSubscriptionOperation operation = new VolatileSubscriptionOperation(
                     task.result,
                     task.streamId, task.resolveLinkTos, task.userCredentials, task.listener,
-                    () -> connection, executor());
+                    () -> connection, settings.actionQueueCongestionTimeout, executor());
 
                 logger.debug("StartSubscription {} {}, {}, {}, {}.",
                     state == ConnectionState.CONNECTED ? "fire" : "enqueue",
@@ -965,7 +965,7 @@ public class EventStoreTcp implements EventStore {
                 PersistentSubscriptionOperation operation = new PersistentSubscriptionOperation(
                     task.result,
                     task.subscriptionId, task.streamId, task.bufferSize, task.userCredentials, task.listener,
-                    () -> connection, executor());
+                    () -> connection, settings.actionQueueCongestionTimeout, executor());
 
                 logger.debug("StartSubscription {} {}, {}, {}, {}.",
                     state == ConnectionState.CONNECTED ? "fire" : "enqueue",

--- a/src/main/java/com/github/msemys/esjc/Settings.java
+++ b/src/main/java/com/github/msemys/esjc/Settings.java
@@ -133,6 +133,11 @@ public class Settings {
     public final boolean disconnectOnTcpChannelError;
 
     /**
+     * Time to wait for congestion in action queue to clear before failing
+     */
+    public final Duration actionQueueCongestionTimeout;
+
+    /**
      * The executor to execute client internal tasks (such as establish-connection, start-operation) and run subscriptions.
      */
     public final Executor executor;
@@ -159,6 +164,7 @@ public class Settings {
         failOnNoServerResponse = builder.failOnNoServerResponse;
         disconnectOnTcpChannelError = builder.disconnectOnTcpChannelError;
         executor = builder.executor;
+        actionQueueCongestionTimeout = builder.actionQueueCongestionTimeout;
     }
 
     @Override
@@ -184,6 +190,7 @@ public class Settings {
         sb.append(", persistentSubscriptionAutoAck=").append(persistentSubscriptionAutoAck);
         sb.append(", failOnNoServerResponse=").append(failOnNoServerResponse);
         sb.append(", disconnectOnTcpChannelError=").append(disconnectOnTcpChannelError);
+        sb.append(", actionQueueCongestionTimeout=").append(actionQueueCongestionTimeout);
         sb.append(", executor=").append(executor);
         sb.append('}');
         return sb.toString();
@@ -222,6 +229,7 @@ public class Settings {
         private Boolean persistentSubscriptionAutoAck;
         private Boolean failOnNoServerResponse;
         private Boolean disconnectOnTcpChannelError;
+        private Duration actionQueueCongestionTimeout;
         private Executor executor;
 
         private Builder() {
@@ -485,6 +493,11 @@ public class Settings {
             return this;
         }
 
+        public Builder actionQueueCongestionTimeout(Duration actionQueueCongestionTimeout) {
+            this.actionQueueCongestionTimeout = actionQueueCongestionTimeout;
+            return this;
+        }
+
         /**
          * Sets the executor to execute client internal tasks (such as establish-connection, start-operation) and run subscriptions.
          *
@@ -591,6 +604,12 @@ public class Settings {
 
             if (disconnectOnTcpChannelError == null) {
                 disconnectOnTcpChannelError = false;
+            }
+
+            if (actionQueueCongestionTimeout == null) {
+                actionQueueCongestionTimeout = Duration.ofSeconds(30);
+            } else {
+                checkArgument(!actionQueueCongestionTimeout.isNegative(), "actionQueueCongestionTimeout is negative");
             }
 
             if (executor == null) {

--- a/src/main/java/com/github/msemys/esjc/subscription/AbstractSubscriptionOperation.java
+++ b/src/main/java/com/github/msemys/esjc/subscription/AbstractSubscriptionOperation.java
@@ -263,7 +263,7 @@ public abstract class AbstractSubscriptionOperation<T extends Subscription, E ex
                 drop(SubscriptionDropReason.ProcessingQueueOverflow, new SubscriptionBufferOverflowException("client buffer too big"));
             }
         } catch (InterruptedException ex) {
-            throw new RuntimeException(ex);
+            drop(SubscriptionDropReason.UserInitiated, ex);
         }
 
         if (actionExecuting.compareAndSet(false, true)) {

--- a/src/main/java/com/github/msemys/esjc/subscription/AllCatchUpSubscription.java
+++ b/src/main/java/com/github/msemys/esjc/subscription/AllCatchUpSubscription.java
@@ -3,6 +3,7 @@ package com.github.msemys.esjc.subscription;
 import com.github.msemys.esjc.*;
 import com.github.msemys.esjc.util.Strings;
 
+import java.time.Duration;
 import java.util.concurrent.Executor;
 
 import static com.github.msemys.esjc.util.Threads.sleepUninterruptibly;
@@ -18,8 +19,9 @@ public class AllCatchUpSubscription extends CatchUpSubscription {
                                   UserCredentials userCredentials,
                                   int readBatchSize,
                                   int maxPushQueueSize,
+                                  Duration maxWaitForPushQueue,
                                   Executor executor) {
-        super(eventstore, Strings.EMPTY, resolveLinkTos, listener, userCredentials, readBatchSize, maxPushQueueSize, executor);
+        super(eventstore, Strings.EMPTY, resolveLinkTos, listener, userCredentials, readBatchSize, maxPushQueueSize, maxWaitForPushQueue, executor);
         lastProcessedPosition = (position == null) ? Position.END : position;
         nextReadPosition = (position == null) ? Position.START : position;
     }

--- a/src/main/java/com/github/msemys/esjc/subscription/PersistentSubscriptionOperation.java
+++ b/src/main/java/com/github/msemys/esjc/subscription/PersistentSubscriptionOperation.java
@@ -13,6 +13,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.MessageLite;
 import io.netty.channel.Channel;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -36,8 +37,9 @@ public class PersistentSubscriptionOperation extends AbstractSubscriptionOperati
                                            UserCredentials userCredentials,
                                            SubscriptionListener<PersistentSubscriptionChannel, RetryableResolvedEvent> listener,
                                            Supplier<Channel> connectionSupplier,
+                                           Duration maxCongestionWaitTime,
                                            Executor executor) {
-        super(result, TcpCommand.ConnectToPersistentSubscription, streamId, false, userCredentials, listener, connectionSupplier, executor);
+        super(result, TcpCommand.ConnectToPersistentSubscription, streamId, false, userCredentials, listener, connectionSupplier, maxCongestionWaitTime, executor);
         this.groupName = groupName;
         this.bufferSize = bufferSize;
     }

--- a/src/main/java/com/github/msemys/esjc/subscription/StreamCatchUpSubscription.java
+++ b/src/main/java/com/github/msemys/esjc/subscription/StreamCatchUpSubscription.java
@@ -4,6 +4,7 @@ import com.github.msemys.esjc.*;
 import com.github.msemys.esjc.operation.StreamDeletedException;
 import com.github.msemys.esjc.operation.StreamNotFoundException;
 
+import java.time.Duration;
 import java.util.concurrent.Executor;
 
 import static com.github.msemys.esjc.util.Preconditions.checkArgument;
@@ -22,8 +23,9 @@ public class StreamCatchUpSubscription extends CatchUpSubscription {
                                      UserCredentials userCredentials,
                                      int readBatchSize,
                                      int maxPushQueueSize,
+                                     Duration maxWaitForPushQueue,
                                      Executor executor) {
-        super(eventstore, streamId, resolveLinkTos, listener, userCredentials, readBatchSize, maxPushQueueSize, executor);
+        super(eventstore, streamId, resolveLinkTos, listener, userCredentials, readBatchSize, maxPushQueueSize, maxWaitForPushQueue, executor);
         checkArgument(!isNullOrEmpty(streamId), "streamId is null or empty");
         lastProcessedEventNumber = (eventNumber == null) ? StreamPosition.END : eventNumber;
         nextReadEventNumber = (eventNumber == null) ? StreamPosition.START : eventNumber;

--- a/src/main/java/com/github/msemys/esjc/subscription/VolatileSubscriptionOperation.java
+++ b/src/main/java/com/github/msemys/esjc/subscription/VolatileSubscriptionOperation.java
@@ -14,6 +14,7 @@ import com.github.msemys.esjc.tcp.TcpPackage;
 import com.google.protobuf.MessageLite;
 import io.netty.channel.Channel;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
@@ -27,8 +28,9 @@ public class VolatileSubscriptionOperation extends AbstractSubscriptionOperation
                                          UserCredentials userCredentials,
                                          SubscriptionListener listener,
                                          Supplier<Channel> connectionSupplier,
+                                         Duration maxCongestionWaitTime,
                                          Executor executor) {
-        super(result, TcpCommand.SubscribeToStream, streamId, resolveLinkTos, userCredentials, listener, connectionSupplier, executor);
+        super(result, TcpCommand.SubscribeToStream, streamId, resolveLinkTos, userCredentials, listener, connectionSupplier, maxCongestionWaitTime, executor);
     }
 
     @Override


### PR DESCRIPTION
We have seen some issues with 'SubscriptionBufferOverflowException' when large amounts of events are available for reading. The exceptions them selves then cause additional delays. The idea behind this pull-request is to allow for a more grace full handling of congestion. By using BlockingQueue we slow down the fastest code paths when they get to far ahead.