### PR TITLE
Create new InetSocketAddress on SingleEndpoint discovery

### DIFF
--- a/src/main/java/com/github/msemys/esjc/node/single/SingleEndpointDiscoverer.java
+++ b/src/main/java/com/github/msemys/esjc/node/single/SingleEndpointDiscoverer.java
@@ -10,18 +10,20 @@ import static com.github.msemys.esjc.util.Preconditions.checkNotNull;
 
 public class SingleEndpointDiscoverer implements EndpointDiscoverer {
 
-    private final CompletableFuture<NodeEndpoints> result;
+    private final SingleNodeSettings settings;
+    private final boolean ssl;
 
     public SingleEndpointDiscoverer(SingleNodeSettings settings, boolean ssl) {
         checkNotNull(settings, "settings is null");
-        result = CompletableFuture.completedFuture(new NodeEndpoints(
-            ssl ? null : settings.address,
-            ssl ? settings.address : null));
+        this.settings = settings;
+        this.ssl = ssl;
     }
 
     @Override
     public CompletableFuture<NodeEndpoints> discover(InetSocketAddress failedTcpEndpoint) {
-        return result;
+        return CompletableFuture.completedFuture(new NodeEndpoints(
+                ssl ? null : settings.address,
+                ssl ? settings.address : null));
     }
 
 }

--- a/src/main/java/com/github/msemys/esjc/node/single/SingleEndpointDiscoverer.java
+++ b/src/main/java/com/github/msemys/esjc/node/single/SingleEndpointDiscoverer.java
@@ -21,9 +21,12 @@ public class SingleEndpointDiscoverer implements EndpointDiscoverer {
 
     @Override
     public CompletableFuture<NodeEndpoints> discover(InetSocketAddress failedTcpEndpoint) {
+        // construct new address to handle ip address changes between discovers
+        InetSocketAddress freshAddress =
+                new InetSocketAddress(settings.address.getHostName(), settings.address.getPort());
         return CompletableFuture.completedFuture(new NodeEndpoints(
-                ssl ? null : settings.address,
-                ssl ? settings.address : null));
+                ssl ? null : freshAddress,
+                ssl ? freshAddress : null));
     }
 
 }


### PR DESCRIPTION
We are using a single ES-Node in a Kubernetes cluster and use esjc in several Kotlin Clients. If the pod running ES dies and another pod with the same hostname starts, esjc can not reconnect because it creates the InetSocketAddress (and resolves the IP address) once when the SingleNodeSettings are build and then uses it on reconnect, instead of getting a new InetSocketAddress. 

My solution is now to create a new InetSocketAddress on each `SingleEndpointDiscover.discover()` call, with this workaround the hostname is always resolved to the correct IP address and the reconnect succeds. 

I am not sure if my solution solves the problem in general, it works for me using hostname and port for SingleNodeSettings.

If it is possible to provide a better solution I would be happy to implement it with some guidance. 